### PR TITLE
Enable show slaves config option

### DIFF
--- a/root/templates/orchestrator.conf.json
+++ b/root/templates/orchestrator.conf.json
@@ -3,5 +3,6 @@
   "ListenAddress": ":3000",
   "BackendDB": "sqlite",
   "SQLite3DataFile": "/var/lib/orchestrator/orc.db",
-  "MySQLTopologyCredentialsConfigFile": "/etc/orchestrator/orc-topology.cnf"
+  "MySQLTopologyCredentialsConfigFile": "/etc/orchestrator/orc-topology.cnf",
+  "DiscoverByShowSlaveHosts": {{ default .Env.ORC_USE_SHOW_SLAVES "false" | lower }}
 }


### PR DESCRIPTION
By default orchestrator does not use mysql show slaves command to discover slaves. Due to this, it fails to discover slaves of a mysql instance on baremetal k8s cluster. This option will enable it to discover replicas properly on such setups.