### PR TITLE
Fix rafting issues.

### DIFF
--- a/charts/orchestrator/Chart.yaml
+++ b/charts/orchestrator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: orchestrator
-version: 0.1.6
+version: 0.1.7
 appVersion: 3.0.14
 description: A Helm chart for github's mysql orchestrator
 keywords:

--- a/charts/orchestrator/templates/_helpers.tpl
+++ b/charts/orchestrator/templates/_helpers.tpl
@@ -30,3 +30,23 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{ $fullname }}-{{ $i }}-svc{{- if lt $i (sub $replicas 1) }},{{ end }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "orchestrator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "orchestrator.labels" -}}
+app.kubernetes.io/name: {{ include "orchestrator.name" . }}
+helm.sh/chart: {{ include "orchestrator.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/charts/orchestrator/templates/_helpers.tpl
+++ b/charts/orchestrator/templates/_helpers.tpl
@@ -27,6 +27,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $fullname := include "orchestrator.fullname" . -}}
 {{- $replicas := int .Values.replicas -}}
 {{- range $i := until $replicas -}}
-{{ $fullname }}-{{ $i }}.{{ $fullname }}-headless{{- if lt $i (sub $replicas 1) }},{{ end }}
+{{ $fullname }}-{{ $i }}-svc{{- if lt $i (sub $replicas 1) }},{{ end }}
 {{- end -}}
 {{- end -}}

--- a/charts/orchestrator/templates/config.yaml
+++ b/charts/orchestrator/templates/config.yaml
@@ -8,7 +8,9 @@
 {{- $_ := set $conf "SQLite3DataFile" "/var/lib/orchestrator/orc.db" }}
 {{- $_ := set $conf "RaftEnabled" true }}
 {{- $_ := set $conf "RaftDataDir" "/var/lib/orchestrator" }}
-{{- $_ := set $conf "RaftBind" (printf "{{ .Env.HOSTNAME }}.%s-headless" $fullname) }}
+{{- $_ := set $conf "RaftAdvertise" "{{ .Env.HOSTNAME }}-svc" }}
+{{- $_ := set $conf "RaftBind" "{{ .Env.HOSTNAME }}" }}
+{{- $_ := set $conf "HTTPAdvertise" "http://{{ .Env.HOSTNAME }}-svc:80" }}
 {{- if eq 1 $replicas -}}
 {{- $_ := set $conf "RaftNodes" (list) }}
 {{- else -}}

--- a/charts/orchestrator/templates/ingress.yaml
+++ b/charts/orchestrator/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "orchestrator.fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+{{ include "orchestrator.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/orchestrator/templates/service.yaml
+++ b/charts/orchestrator/templates/service.yaml
@@ -42,7 +42,7 @@ spec:
     selector:
         app: {{ template "orchestrator.fullname" . }}
     ports:
-    - name: web
+    - name: http
       port: {{ .Values.service.port }}
       protocol: TCP
       targetPort: 3000

--- a/charts/orchestrator/templates/service.yaml
+++ b/charts/orchestrator/templates/service.yaml
@@ -1,44 +1,51 @@
+{{- $fullName := include "orchestrator.fullname" . }}
+{{- $replicas := int .Values.replicas -}}
+{{- range $i := until $replicas -}}
+{{/*this service is needed for rafting. https://github.com/presslabs/mysql-operator/issues/107*/}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "orchestrator.fullname" . }}-headless
-  labels:
-    app: {{ template "orchestrator.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    name: {{$fullName}}-{{$i}}-svc
+    labels:
+        app: {{$fullName}}
+        chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+        release: "{{ $.Release.Name }}"
+        heritage: "{{ $.Release.Service }}"
+    annotations:
+        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
-  clusterIP: None
-  ports:
+    type: ClusterIP
+    ports:
     - name: web
       port: 80
       targetPort: 3000
     - name: raft
       port: 10008
       targetPort: 10008
-  selector:
-    app: {{ template "orchestrator.fullname" . }}
+    selector:
+        statefulset.kubernetes.io/pod-name: {{$fullName}}-{{$i}}
 ---
+{{end}}
+---
+{{/*{orchestrator will make sure that this service always talks to the leader}*/}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "orchestrator.fullname" . }}
-  labels:
-    app: {{ template "orchestrator.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    name: {{ template "orchestrator.fullname" . }}
+    labels:
+        app: {{ template "orchestrator.fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        heritage: "{{ .Release.Service }}"
 spec:
-  type: {{ .Values.service.type }}
-  selector:
-    app: {{ template "orchestrator.fullname" . }}
-  ports:
+    type: {{ .Values.service.type }}
+    selector:
+        app: {{ template "orchestrator.fullname" . }}
+    ports:
     - name: web
       port: {{ .Values.service.port }}
       protocol: TCP
       targetPort: 3000
-      {{- if .Values.service.nodePort }}
+            {{- if .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
-      {{- end }}
+        {{- end }}

--- a/charts/orchestrator/values.yaml
+++ b/charts/orchestrator/values.yaml
@@ -44,6 +44,20 @@ service:
   port: 80
   # nodePort: 3000
 
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
+  hosts:
+  - host: chart-example.local
+    paths: []
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
 topologyUser: orchestrator
 # topologyPassword:
 


### PR DESCRIPTION
This commit ensures that each pod has its own cluster IP service. This
makes sure that "pod ips" do not change. Fixes
presslabs/docker-orchestrator/#4.

Orchestrator can automatically route traffic to the leader. By making a
service that talks to all pods + using the right http advertise config
value.

Fixes presslabs/docker-orchestrator#4
Fixes presslabs/mysql-operator#107